### PR TITLE
Add AutoHotkey port of Idle Runner automation

### DIFF
--- a/Autohotkey/Idle Runner.ahk
+++ b/Autohotkey/Idle Runner.ahk
@@ -1,0 +1,651 @@
+#Requires AutoHotkey v2.0
+#SingleInstance Force
+#NoTrayIcon
+
+#Include "Libraries/Common.ahk"
+#Include "Libraries/BonusStage.ahk"
+#Include "Libraries/BossFightVictor.ahk"
+#Include "Libraries/BossFightKnight.ahk"
+#Include "Libraries/ChestHunt.ahk"
+#Include "Libraries/AscendingHeights.ahk"
+
+Global bAutoBuyUpgradeState := false
+Global bCraftSoulBonusState := false
+Global bSkipBonusStageState := false
+Global bCraftRagePillState := false
+Global bCirclePortalsState := false
+Global bNoLockpickingState := true
+Global bNoReinforcedCrystalSaverState := false
+Global bBiDimensionalState := false
+Global bDimensionalState := false
+Global bDisableRageState := false
+Global bAutoAscendState := false
+Global bPerfectChestHuntState := false
+Global bTogglePause := false
+
+Global sVersion := "3.5.3"
+Global iJumpSliderValue := 150
+Global iCirclePortalsCount := 7
+Global iAutoAscendTimer := 10
+Global iAutoBuyTimer := 10
+Global iAutoBuyTempTimer := 10
+Global iAutoBuyLoopAmount := 0
+Global iTimerAutoBuy := TimerInit()
+Global iTimerAutoAscend := TimerInit()
+Global iTimerFocusGame := TimerInit()
+Global iLastCheckTimeLoop := TimerInit()
+
+Global jumpState := true
+Global jumpDelay := iJumpSliderValue
+
+Global mainGui
+Global startStopBtn
+Global jumpSlider
+Global autoAscendInput
+Global autoBuyInput
+Global circlePortalInput
+Global statusText
+
+setSetting()
+InitUI()
+LoadSettings()
+ShowGUI()
+
+Hotkey "Home", Pause
+Hotkey "+Esc", IdleClose
+Hotkey "^+b", AutoUpgrade
+
+SetTimer ShootAndBoostTick, 50
+SetTimer MainLoop, -10
+return
+
+InitUI() {
+    Global mainGui, startStopBtn, jumpSlider, autoAscendInput, autoBuyInput, circlePortalInput, statusText
+
+    mainGui := GuiCreate("+AlwaysOnTop", "Idle Runner v" sVersion)
+    mainGui.OnEvent("Close", IdleClose)
+
+    mainGui.AddText("Section", "General")
+    mainGui.AddCheckBox("vAutoBuyUpgradeState", "Auto buy upgrades").OnEvent("Click", ToggleCheckbox)
+    mainGui.AddCheckBox("vAutoAscendState", "Auto ascend").OnEvent("Click", ToggleCheckbox)
+    mainGui.AddCheckBox("vCirclePortalsState", "Circle portals").OnEvent("Click", ToggleCheckbox)
+    mainGui.AddCheckBox("vDisableRageState", "Disable rage without soul bonus").OnEvent("Click", ToggleCheckbox)
+
+    mainGui.AddText("Section xm", "Crafting")
+    mainGui.AddCheckBox("vCraftSoulBonusState", "Craft soul bonus").OnEvent("Click", ToggleCheckbox)
+    mainGui.AddCheckBox("vCraftRagePillState", "Craft rage pill").OnEvent("Click", ToggleCheckbox)
+    mainGui.AddCheckBox("vDimensionalState", "Craft dimensional staff").OnEvent("Click", ToggleCheckbox)
+    mainGui.AddCheckBox("vBiDimensionalState", "Craft bidimensional staff").OnEvent("Click", ToggleCheckbox)
+
+    mainGui.AddText("Section xm", "Minigames")
+    mainGui.AddCheckBox("vSkipBonusStageState", "Skip bonus stage").OnEvent("Click", ToggleCheckbox)
+    mainGui.AddCheckBox("vNoLockpickingState", "No lockpicking (chest hunt)").OnEvent("Click", ToggleCheckbox)
+    mainGui.AddCheckBox("vPerfectChestHuntState", "Perfect chest hunt").OnEvent("Click", ToggleCheckbox)
+    mainGui.AddCheckBox("vNoReinforcedCrystalSaverState", "No reinforced crystal saver").OnEvent("Click", ToggleCheckbox)
+
+    mainGui.AddText("Section xm", "Jump delay (ms)")
+    jumpSlider := mainGui.AddSlider("Range40-400 TickInterval20 vJumpSliderValue", iJumpSliderValue)
+    jumpSlider.OnEvent("Change", UpdateSlider)
+
+    mainGui.AddText("xm", "Auto ascend every (minutes)")
+    autoAscendInput := mainGui.AddEdit("Number Limit3 w80 vAutoAscendTimer", iAutoAscendTimer)
+    autoAscendInput.OnEvent("Change", UpdateTimers)
+
+    mainGui.AddText("xm", "Auto buy every (minutes)")
+    autoBuyInput := mainGui.AddEdit("Number Limit3 w80 vAutoBuyTimer", iAutoBuyTimer)
+    autoBuyInput.OnEvent("Change", UpdateTimers)
+
+    mainGui.AddText("xm", "Circle portals count")
+    circlePortalInput := mainGui.AddEdit("Number Limit2 w80 vCirclePortalsCount", iCirclePortalsCount)
+    circlePortalInput.OnEvent("Change", UpdateTimers)
+
+    startStopBtn := mainGui.AddButton("Default xm w120", "Pause")
+    startStopBtn.OnEvent("Click", Pause)
+
+    mainGui.AddButton("x+m w120", "Exit").OnEvent("Click", IdleClose)
+
+    statusText := mainGui.AddText("xm w260", "Running...")
+}
+
+ShowGUI() {
+    Global mainGui
+    mainGui.Show()
+}
+
+ToggleCheckbox(ctrl, info) {
+    global bAutoBuyUpgradeState, bAutoAscendState, bCirclePortalsState, bDisableRageState
+    global bCraftSoulBonusState, bCraftRagePillState, bDimensionalState, bBiDimensionalState
+    global bSkipBonusStageState, bNoLockpickingState, bPerfectChestHuntState, bNoReinforcedCrystalSaverState
+    value := ctrl.Value = 1
+    switch ctrl.Name {
+        case "AutoBuyUpgradeState":
+            bAutoBuyUpgradeState := value
+        case "AutoAscendState":
+            bAutoAscendState := value
+        case "CirclePortalsState":
+            bCirclePortalsState := value
+        case "DisableRageState":
+            bDisableRageState := value
+        case "CraftSoulBonusState":
+            bCraftSoulBonusState := value
+        case "CraftRagePillState":
+            bCraftRagePillState := value
+        case "DimensionalState":
+            bDimensionalState := value
+        case "BiDimensionalState":
+            bBiDimensionalState := value
+        case "SkipBonusStageState":
+            bSkipBonusStageState := value
+        case "NoLockpickingState":
+            bNoLockpickingState := value
+        case "PerfectChestHuntState":
+            bPerfectChestHuntState := value
+        case "NoReinforcedCrystalSaverState":
+            bNoReinforcedCrystalSaverState := value
+    }
+    SaveSettings()
+}
+
+UpdateSlider(ctrl, info) {
+    global iJumpSliderValue, jumpDelay
+    iJumpSliderValue := ctrl.Value
+    jumpDelay := iJumpSliderValue
+    SaveSettings()
+}
+
+UpdateTimers(ctrl, info) {
+    global iAutoAscendTimer, iAutoBuyTimer, iCirclePortalsCount, iAutoBuyTempTimer
+    switch ctrl.Name {
+        case "AutoAscendTimer":
+            iAutoAscendTimer := Max(1, ctrl.Value)
+        case "AutoBuyTimer":
+            iAutoBuyTimer := Max(1, ctrl.Value)
+            iAutoBuyTempTimer := iAutoBuyTimer
+        case "CirclePortalsCount":
+            iCirclePortalsCount := Max(1, ctrl.Value)
+    }
+    SaveSettings()
+}
+
+MainLoop() {
+    Global bTogglePause, iTimerFocusGame, iLastCheckTimeLoop, bCirclePortalsState
+    Global bAutoBuyUpgradeState, iAutoBuyTimer, iAutoBuyTempTimer, iTimerAutoBuy, iAutoBuyLoopAmount
+    Global bAutoAscendState, iTimerAutoAscend, iAutoAscendTimer
+    Global bSkipBonusStageState, bNoLockpickingState, bPerfectChestHuntState, bNoReinforcedCrystalSaverState
+
+    Loop {
+        Sleep 40
+        if bTogglePause
+            continue
+
+        if TimerDiff(iTimerFocusGame) > 1800000 {
+            iTimerFocusGame := TimerInit()
+            WinActivate "Idle Slayer"
+            ControlFocus "Idle Slayer"
+        }
+
+        if PixelFind(650, 36, 650, 36, 0xCA9700) {
+            WriteInLogs("Silver Box Collected")
+            MouseClick "L", 644, 49, 1, 0
+        }
+
+        if PixelFind(419, 323, 419, 323, 0xDFDEE0) {
+            SyncProcess(false)
+            RageWhenHorde()
+            SyncProcess(true)
+        }
+
+        if PixelFind(1130, 610, 1130, 610, 0xCBCB4C) {
+            SyncProcess(false)
+            ClaimQuests()
+            SyncProcess(true)
+        }
+
+        if PixelFind(625, 143, 629, 214, 0xA86D0A) {
+            ControlFocus "Idle Slayer"
+            Send "{r}"
+        }
+
+        if PixelFind(99, 113, 99, 113, 0xFFFF7A) {
+            SyncProcess(false)
+            CollectMinion()
+            SyncProcess(true)
+        }
+
+        if TimerDiff(iLastCheckTimeLoop) >= 5000 {
+            iLastCheckTimeLoop := TimerInit()
+            CloseAll()
+
+            if PixelFind(660, 254, 660, 254, 0xFFE737) && PixelFind(638, 236, 638, 236, 0xFFBB31) && PixelFind(775, 448, 775, 448, 0xFFFFFF) {
+                SyncProcess(false)
+                BonusStage(bSkipBonusStageState)
+                SyncProcess(true)
+            }
+
+            if PixelFind(639, 224, 639, 224, 0xFF878A) && PixelFind(634, 224, 634, 224, 0xF263BD) && PixelFind(644, 224, 644, 224, 0xFFF38F) {
+                SyncProcess(false)
+                if PixelFind(30, 690, 30, 690, 0x0B0303) {
+                    BossFightKnight()
+                } else {
+                    BossFightVictor()
+                }
+                SyncProcess(true)
+            }
+
+            if PixelFind(671, 213, 671, 213, 0xC2F4F9) && PixelFind(640, 240, 634, 640, 0xFFCC66) {
+                SyncProcess(false)
+                AscendingHeights()
+                SyncProcess(true)
+            }
+
+            if bCirclePortalsState {
+                CirclePortals()
+            }
+
+            if bAutoBuyUpgradeState {
+                if TimerDiff(iTimerAutoBuy) > (iAutoBuyTempTimer * 60000) {
+                    iTimerAutoBuy := TimerInit()
+                    iAutoBuyTempTimer := iAutoBuyTimer
+                    WinActivate "Idle Slayer"
+                    if WinActive("Idle Slayer") {
+                        SyncProcess(false)
+                        iAutoBuyLoopAmount := 0
+                        AutoUpgrade()
+                        SyncProcess(true)
+                    }
+                }
+            }
+
+            if bAutoAscendState {
+                if TimerDiff(iTimerAutoAscend) > (iAutoAscendTimer * 60000) {
+                    iTimerAutoAscend := TimerInit()
+                    WinActivate "Idle Slayer"
+                    if WinActive("Idle Slayer") {
+                        SyncProcess(false)
+                        AutoAscend()
+                        SyncProcess(true)
+                    }
+                }
+            }
+        }
+    }
+}
+
+CloseAll() {
+    Sleep 2000
+    if PixelFind(680, 593, 680, 593, 0xAF0000) {
+        MouseClick "L", 780, 600, 1, 0
+    }
+}
+
+RageWhenHorde() {
+    Global bCraftRagePillState, bCraftSoulBonusState, bDisableRageState
+    soulBonus := CheckForSoulBonus()
+    if soulBonus {
+        if bCraftRagePillState {
+            BuyTempItem(0x871646)
+        }
+        if bCraftSoulBonusState {
+            BuyTempItem(0x7D55D8)
+        }
+    }
+    if bDisableRageState {
+        if soulBonus {
+            Rage()
+        }
+    } else {
+        Rage()
+    }
+}
+
+Rage() {
+    Global bDimensionalState, bBiDimensionalState
+    WriteInLogs("MegaHorde Rage")
+    if bDimensionalState {
+        BuyTempItem(0xF37C55)
+        bDimensionalState := false
+        SaveSettings()
+    }
+    if bBiDimensionalState {
+        BuyTempItem(0x526629)
+        bBiDimensionalState := false
+        SaveSettings()
+    }
+    ControlFocus "Idle Slayer"
+    Send "{r}"
+}
+
+CheckForSoulBonus() {
+    return PixelFind(625, 143, 629, 214, 0xA86D0A) != false
+}
+
+BuyTempItem(color) {
+    WriteInLogs("Trying to CraftingTemp Item")
+    MouseClick "L", 160, 100, 1, 0
+    Sleep 150
+    MouseClick "L", 260, 690, 1, 0
+    Sleep 150
+    if coords := PixelFind(43, 330, 625, 630, color) {
+        MouseClick "L", coords[1], coords[2], 1, 0
+        Sleep 200
+        MouseClick "L", 407, 213, 1, 0
+        WriteInLogs("CraftingTemp Item Active")
+    } else {
+        WriteInLogs("CraftingTemp Item Failed, not enough materials")
+    }
+    MouseClick "L", 440, 690, 1, 0
+    Sleep 100
+}
+
+AutoAscend() {
+    if PixelFind(260, 600, 260, 600, 0x58188D) {
+        MouseClick "L", 260, 600, 1, 0
+        Sleep 300
+        MouseClick "L", 550, 580, 1, 0
+        Sleep 300
+        AutoUpgrade()
+    } else {
+        MouseClick "L", 95, 90, 1, 0
+        Sleep 400
+        MouseClick "L", 93, 680, 1, 0
+        Sleep 400
+        if PixelFind(260, 600, 260, 600, 0x58188D) {
+            MouseClick "L", 260, 600, 1, 0
+            Sleep 300
+            MouseClick "L", 550, 580, 1, 0
+            Sleep 300
+            AutoUpgrade()
+        }
+    }
+}
+
+CollectMinion() {
+    MouseClick "L", 95, 90, 1, 0
+    Sleep 400
+    MouseClick "L", 93, 680, 1, 0
+    Sleep 200
+    MouseClick "L", 193, 680, 1, 0
+    Sleep 200
+    MouseClick "L", 691, 680, 1, 0
+    Sleep 200
+    MouseClick "L", 332, 680, 1, 0
+    Sleep 200
+
+    if PixelFind(370, 410, 910, 470, 0x11AA23, 9) {
+        MouseClick "L", 320, 280, 5, 0
+        Sleep 200
+        MouseClick "L", 320, 280, 5, 0
+        Sleep 200
+        MouseClick "L", 320, 180, 5, 0
+        Sleep 200
+        WriteInLogs("Minions Collect with Daily Bonus")
+    } else {
+        MouseClick "L", 318, 182, 5, 0
+        Sleep 200
+        MouseClick "L", 318, 182, 5, 0
+        Sleep 200
+        WriteInLogs("Minions Collect")
+    }
+
+    MouseClick "L", 570, 694, 1, 0
+}
+
+CirclePortals() {
+    if !PixelFind(1180, 166, 1180, 166, 0x830399) && !PixelFind(1180, 166, 1180, 166, 0x290130)
+        return
+
+    if !PixelFind(1154, 144, 1210, 155, 0xFFFFFF, 9) {
+        SyncProcess(false)
+        MouseClick "L", 1180, 150, 1, 0
+        Sleep 200
+        MouseClick "L", 928, 682, 1, 0
+        Sleep 200
+        Loop iCirclePortalsCount {
+            MouseClick "L", 1102, 412, 1, 0
+            Sleep 1200
+        }
+        MouseClick "L", 1180, 150, 1, 0
+        Sleep 200
+        SyncProcess(true)
+    }
+}
+
+AutoUpgrade() {
+    Global iAutoBuyLoopAmount
+    WriteInLogs("AutoUpgrade Active")
+    MouseClick "L", 1244, 712, 1, 0
+    Sleep 150
+    MouseClick "L", 1163, 655, 1, 0
+    Sleep 150
+    if PixelFind(807, 140, 807, 155, 0xFFFFFF) {
+        BuyUpgrade()
+    }
+}
+
+BuyEquipment() {
+    Global iAutoBuyLoopAmount
+    MouseClick "L", 850, 690, 1, 0
+    Sleep 50
+    MouseClick "L", 1180, 636, 4, 0
+    if PixelFind(1257, 340, 1257, 340, 0x11AA23) {
+        MouseClick "L", 1200, 200, 5, 0
+    } else {
+        MouseClick "L", 1253, 592, 5, 0
+        Sleep 200
+    }
+    while true {
+        if coords := PixelFind(1160, 590, 1160, 170, 0x11AA23, 10) {
+            MouseClick "L", 850, 690, 1, 0
+            MouseClick "L", coords[1], coords[2], 5, 0
+        } else {
+            MouseMove 1260, 170, 0
+            MouseWheel "Up", 1
+            if !PixelFind(1260, 168, 1260, 168, 0xD6D6D6)
+                break
+            Sleep 10
+        }
+    }
+    BuyUpgrade()
+}
+
+BuyUpgrade() {
+    Global iAutoBuyLoopAmount
+    MouseClick "L", 927, 683, 1, 0
+    Sleep 150
+    MouseMove 1254, 172, 0
+    Loop {
+        MouseWheel "Up", 20
+    } until !PixelFind(1254, 167, 1254, 167, 0xD6D6D6)
+    Sleep 400
+    bought := false
+    y := 170
+    while true {
+        if PixelFind(882, y, 909, y + 72, 0xF4B41B)
+            y += 96
+        if PixelFind(882, y, 909, y + 72, 0xE478FF)
+            y += 96
+        if !(PixelFind(1180, y + 10, 1180, y + 10, 0x11A622) || PixelFind(1180, y + 10, 1180, y + 10, 0x0C7418))
+            break
+        bought := true
+        MouseClick "L", 1180, y, 1, 0
+        Sleep 50
+    }
+    if bought && iAutoBuyLoopAmount < 6 {
+        iAutoBuyLoopAmount++
+        BuyEquipment()
+    } else {
+        MouseClick "L", 1222, 677, 1, 0
+    }
+}
+
+ClaimQuests() {
+    MouseClick "L", 1244, 712, 1, 0
+    Sleep 150
+    MouseClick "L", 1163, 655, 1, 0
+    Sleep 150
+    MouseClick "L", 850, 690, 1, 0
+    MouseClick "L", 927, 683, 1, 0
+    Sleep 150
+    MouseClick "L", 1000, 690, 1, 0
+    Sleep 50
+    MouseMove 1254, 272, 0
+    Loop {
+        MouseWheel "Up", 20
+    } until !PixelFind(1254, 267, 1254, 267, 0xD6D6D6)
+    Sleep 600
+    while true {
+        if coords := PixelFind(1160, 270, 1160, 590, 0x11A622, 10) {
+            WriteInLogs("Quest Claimed")
+            MouseClick "L", coords[1], coords[2], 1, 0
+        } else {
+            MouseMove 1267, 270, 0
+            MouseWheel "Down", 1
+            if PixelFind(1267, 655, 1267, 655, 0xFFFFFF)
+                break
+            Sleep 100
+        }
+    }
+    MouseClick "L", 1244, 712, 1, 0
+}
+
+ShootAndBoostTick() {
+    Global jumpState, jumpDelay, bTogglePause
+    static lastTick := 0
+    if bTogglePause
+        return
+    if !jumpState
+        return
+    if (A_TickCount - lastTick) < jumpDelay
+        return
+    lastTick := A_TickCount
+    if !WinActive("Idle Runner")
+        ControlFocus "Idle Slayer"
+    Send "{Up}{Right}"
+}
+
+SyncProcess(state := true) {
+    Global jumpState, bTogglePause
+    jumpState := state && !bTogglePause
+}
+
+Pause(*) {
+    Global bTogglePause, startStopBtn, statusText
+    bTogglePause := !bTogglePause
+    if bTogglePause {
+        startStopBtn.Text := "Resume"
+        statusText.Text := "Paused"
+    } else {
+        startStopBtn.Text := "Pause"
+        statusText.Text := "Running..."
+    }
+    SyncProcess(!bTogglePause)
+}
+
+IdleClose(*) {
+    ExitApp
+}
+
+LoadSettings() {
+    Global bAutoBuyUpgradeState, bCraftSoulBonusState, bSkipBonusStageState, bCraftRagePillState
+    Global bCirclePortalsState, bNoLockpickingState, bNoReinforcedCrystalSaverState, bBiDimensionalState
+    Global bDimensionalState, bDisableRageState, bAutoAscendState, bPerfectChestHuntState
+    Global iJumpSliderValue, iCirclePortalsCount, iAutoAscendTimer, iAutoBuyTimer, iAutoBuyTempTimer
+
+    ini := A_ScriptDir "\\IdleRunnerLogs\\Settings.ini"
+    settings := Map(
+        "AutoBuyTimer", iAutoBuyTimer,
+        "AutoAscendTimer", iAutoAscendTimer,
+        "AutoAscendState", bAutoAscendState,
+        "AutoBuyUpgradeState", bAutoBuyUpgradeState,
+        "CraftSoulBonusState", bCraftSoulBonusState,
+        "SkipBonusStageState", bSkipBonusStageState,
+        "CraftRagePillState", bCraftRagePillState,
+        "CirclePortalsState", bCirclePortalsState,
+        "JumpSliderValue", iJumpSliderValue,
+        "NoLockpickingState", bNoLockpickingState,
+        "CirclePortalsCount", iCirclePortalsCount,
+        "DimensionalState", bDimensionalState,
+        "BiDimensionalState", bBiDimensionalState,
+        "DisableRageState", bDisableRageState,
+        "NoReinforcedCrystalSaverState", bNoReinforcedCrystalSaverState,
+        "PerfectChestHuntState", bPerfectChestHuntState
+    )
+
+    for key, default in settings {
+        value := IniRead(ini, "Settings", key, default)
+        if value = "True"
+            value := true
+        else if value = "False"
+            value := false
+        else if RegExMatch(value, "^-?\d+$")
+            value := Integer(value)
+        %key% := value
+    }
+
+    iAutoBuyTempTimer := iAutoBuyTimer
+    jumpDelay := iJumpSliderValue
+    RefreshGUIControls()
+}
+
+SaveSettings() {
+    Global bAutoBuyUpgradeState, bCraftSoulBonusState, bSkipBonusStageState, bCraftRagePillState
+    Global bCirclePortalsState, bNoLockpickingState, bNoReinforcedCrystalSaverState, bBiDimensionalState
+    Global bDimensionalState, bDisableRageState, bAutoAscendState, bPerfectChestHuntState
+    Global iJumpSliderValue, iCirclePortalsCount, iAutoAscendTimer, iAutoBuyTimer
+
+    ini := A_ScriptDir "\\IdleRunnerLogs\\Settings.ini"
+    if !DirExist(A_ScriptDir "\\IdleRunnerLogs")
+        DirCreate A_ScriptDir "\\IdleRunnerLogs"
+
+    data := Map(
+        "AutoBuyTimer", iAutoBuyTimer,
+        "AutoAscendTimer", iAutoAscendTimer,
+        "AutoAscendState", bAutoAscendState,
+        "AutoBuyUpgradeState", bAutoBuyUpgradeState,
+        "CraftSoulBonusState", bCraftSoulBonusState,
+        "SkipBonusStageState", bSkipBonusStageState,
+        "CraftRagePillState", bCraftRagePillState,
+        "CirclePortalsState", bCirclePortalsState,
+        "JumpSliderValue", iJumpSliderValue,
+        "NoLockpickingState", bNoLockpickingState,
+        "CirclePortalsCount", iCirclePortalsCount,
+        "DimensionalState", bDimensionalState,
+        "BiDimensionalState", bBiDimensionalState,
+        "DisableRageState", bDisableRageState,
+        "NoReinforcedCrystalSaverState", bNoReinforcedCrystalSaverState,
+        "PerfectChestHuntState", bPerfectChestHuntState
+    )
+
+    for key, value in data {
+        IniWrite(value, ini, "Settings", key)
+    }
+}
+
+RefreshGUIControls() {
+    Global mainGui, jumpSlider, autoAscendInput, autoBuyInput, circlePortalInput
+    Global bAutoBuyUpgradeState, bCraftSoulBonusState, bSkipBonusStageState, bCraftRagePillState
+    Global bCirclePortalsState, bNoLockpickingState, bNoReinforcedCrystalSaverState, bBiDimensionalState
+    Global bDimensionalState, bDisableRageState, bAutoAscendState, bPerfectChestHuntState
+    Global iJumpSliderValue, iCirclePortalsCount, iAutoAscendTimer, iAutoBuyTimer
+
+    if !IsSet(mainGui)
+        return
+
+    mainGui["AutoBuyUpgradeState"].Value := bAutoBuyUpgradeState ? 1 : 0
+    mainGui["AutoAscendState"].Value := bAutoAscendState ? 1 : 0
+    mainGui["CirclePortalsState"].Value := bCirclePortalsState ? 1 : 0
+    mainGui["DisableRageState"].Value := bDisableRageState ? 1 : 0
+    mainGui["CraftSoulBonusState"].Value := bCraftSoulBonusState ? 1 : 0
+    mainGui["CraftRagePillState"].Value := bCraftRagePillState ? 1 : 0
+    mainGui["DimensionalState"].Value := bDimensionalState ? 1 : 0
+    mainGui["BiDimensionalState"].Value := bBiDimensionalState ? 1 : 0
+    mainGui["SkipBonusStageState"].Value := bSkipBonusStageState ? 1 : 0
+    mainGui["NoLockpickingState"].Value := bNoLockpickingState ? 1 : 0
+    mainGui["PerfectChestHuntState"].Value := bPerfectChestHuntState ? 1 : 0
+    mainGui["NoReinforcedCrystalSaverState"].Value := bNoReinforcedCrystalSaverState ? 1 : 0
+
+    jumpSlider.Value := iJumpSliderValue
+    autoAscendInput.Value := iAutoAscendTimer
+    autoBuyInput.Value := iAutoBuyTimer
+    circlePortalInput.Value := iCirclePortalsCount
+}

--- a/Autohotkey/Libraries/AscendingHeights.ahk
+++ b/Autohotkey/Libraries/AscendingHeights.ahk
@@ -1,0 +1,111 @@
+#Requires AutoHotkey v2.0
+#Include "Common.ahk"
+
+AscendingHeights() {
+    WriteInLogs("Start of Ascending Heights")
+    Loop {
+        Slider()
+        Sleep 500
+        if !PixelFind(640, 240, 634, 640, 0xFFCC66)
+            break
+    }
+    Sleep 3900
+    AscendingHeightsPlay()
+}
+
+AscendingHeightsPlay() {
+    posPlatX := 0
+    posPlatY := 0
+    repeatCount := 0
+    samePlatform := false
+    lastCheck := TimerInit()
+    startTime := TimerInit()
+    while true {
+        if TimerDiff(startTime) >= 240000 {
+            WriteInLogs("Ascending Heights timed out after 4 minutes")
+            cSend(3000, 0, "a")
+            Sleep 100
+            cSend(3000, 0, "d")
+            break
+        }
+
+        if TimerDiff(lastCheck) >= 5000 {
+            lastCheck := TimerInit()
+            if PixelFind(190, 125, 190, 125, 0xFFAF36) {
+                WriteInLogs("Ascending Height Failed")
+                break
+            }
+            if PixelFind(540, 560, 540, 560, 0x00A400) {
+                Sleep 2000
+                MouseClick "L", 560, 570, 1, 0
+            }
+            if PixelFind(700, 385, 730, 385, 0x7A444A) {
+                cSend(15000, 0, "d")
+                WriteInLogs("Ascending Height Won")
+                break
+            }
+        }
+
+        if !(posPlayer := PixelFind(375, 260, 900, 730, 0x633E75))
+            continue
+
+        if !(posPlatform := searchAllPlatformBellowPlayer(posPlayer[1], posPlayer[2], samePlatform))
+            continue
+
+        if (posPlatX = posPlatform[1] && posPlatY = posPlatform[2]) {
+            repeatCount += 1
+            if repeatCount = 5
+                samePlatform := true
+        } else {
+            repeatCount := 0
+            samePlatform := false
+        }
+        posPlatX := posPlatform[1]
+        posPlatY := posPlatform[2]
+
+        if (posPlatform[1] + 35) > (posPlayer[1] + 35) {
+            MouseMove 1100, 600, 0
+            MouseDown "L"
+            Sleep 100
+            MouseUp "L"
+        } else if (posPlatform[1] + 35) < (posPlayer[1] - 35) {
+            MouseMove 100, 600, 0
+            MouseDown "L"
+            Sleep 100
+            MouseUp "L"
+        }
+    }
+}
+
+searchAllPlatformBellowPlayer(playerX, playerY, samePlatform) {
+    if !samePlatform {
+        left := playerX - 130
+        right := playerX + 130
+        if left < 375
+            left := 375
+        if right > 900
+            right := 900
+        posPlatform := PixelFind(left, playerY + 50, right, 752, 0xC0CBDC)
+        if !posPlatform
+            posPlatform := PixelFind(375, playerY + 50, 900, 752, 0xC0CBDC)
+    } else {
+        posPlatform := PixelFind(375, playerY + 50, 900, 752, 0xC0CBDC)
+    }
+
+    if posPlatform {
+        loopCount := 0
+        while true {
+            loopCount += 1
+            if loopCount > 1000
+                return false
+            if !PixelFind(posPlatform[1] + 6, posPlatform[2], posPlatform[1] + 6, posPlatform[2], 0x8B9BB4)
+                return posPlatform
+            if posPlatform[2] + 2 > 752
+                return false
+            posPlatform := PixelFind(375, posPlatform[2] + 1, 900, 752, 0xC0CBDC)
+            if !posPlatform
+                return false
+        }
+    }
+    return posPlatform
+}

--- a/Autohotkey/Libraries/BonusStage.ahk
+++ b/Autohotkey/Libraries/BonusStage.ahk
@@ -1,0 +1,536 @@
+#Requires AutoHotkey v2.0
+#Include "Common.ahk"
+
+BonusStage(skipBonusStageState) {
+    WriteInLogs("Start of BonusStage")
+    Sleep 200
+    bonusStage3 := PixelFind(200, 505, 200, 505, 0x111014) ? true : false
+    Loop {
+        Slider()
+        Sleep 500
+        if !PixelFind(775, 448, 775, 448, 0xFFFFFF)
+            break
+    }
+    if skipBonusStageState {
+        BonusStageDoNothing(bonusStage3 ? 3 : 2)
+        return
+    }
+    Sleep 3900
+    if PixelFind(454, 91, 454, 91, 0xE1E0E2) {
+        if bonusStage3 {
+            BonusStage3SB()
+        } else {
+            BonusStage2SB()
+        }
+    } else {
+        if bonusStage3 {
+            BonusStage3()
+        } else {
+            BonusStage2()
+        }
+    }
+}
+
+BonusStageDoNothing(number) {
+    WriteInLogs("Do nothing BonusStage Active")
+    Loop {
+        Sleep 200
+        if BonusStageFail(number)
+            break
+    }
+}
+
+BonusStageFail(number) {
+    logMsg := "BonusStage" number " Failed"
+    if PixelFind(780, 600, 780, 600, 0xAD0000) {
+        MouseClick "L", 721, 577, 1, 0
+        WriteInLogs(logMsg)
+        return true
+    }
+    if PixelFind(780, 600, 780, 600, 0xB40000) {
+        MouseClick "L", 721, 577, 1, 0
+        WriteInLogs(logMsg)
+        return true
+    }
+    return false
+}
+
+BonusStageRetry(number, spiritBoost) {
+    logMsg := "BonusStage" number (spiritBoost ? "SB" : "")
+    if PixelFind(615, 590, 615, 590, 0x00A400) {
+        MouseClick "L", 560, 600, 1, 0
+        WriteInLogs(logMsg " Retry")
+        Sleep 1000
+        return true
+    }
+    return false
+}
+
+BonusStage2Fail() {
+    return BonusStageFail(2)
+}
+
+BonusStage3Fail(spiritBoost) {
+    logMsg := GetBS3LogText(spiritBoost)
+    if BonusStageRetry(3, spiritBoost)
+        return true
+    if PixelFind(1130, 604, 1130, 604, 0x989898) {
+        WriteInLogs(logMsg " Failed")
+        return true
+    }
+    if PixelFind(115, 570, 125, 590, 0x09439b) {
+        WriteInLogs(logMsg " Failed")
+        return true
+    }
+    if PixelFind(115, 570, 125, 590, 0x099b66) {
+        WriteInLogs(logMsg " Failed")
+        return true
+    }
+    return false
+}
+
+BonusStage2SB() {
+    WriteInLogs("BonusStage2SB")
+    FindPixelUntilFound(220, 465, 220, 465, 0xA0938E)
+    Sleep 200
+    cSend(94, 1640)
+    cSend(47, 2072)
+    cSend(187, 688)
+    cSend(31, 672)
+    cSend(31, 1700)
+    cSend(94, 1640)
+    cSend(47, 2072)
+    cSend(187, 688)
+    cSend(31, 672)
+    cSend(31, 1700)
+    cSend(94, 5000)
+    if BonusStage2Fail()
+        return
+    cSend(40, 2500)
+    Loop 19 {
+        Send "{Up}"
+        Sleep 500
+    }
+    if BonusStage2Fail()
+        return
+    WriteInLogs("BonusStage2SB Section 1 Complete")
+    FindPixelUntilFound(780, 536, 780, 536, 0xBB26DF)
+    cSend(156, 719)
+    cSend(47, 687)
+    cSend(360, 1390)
+    cSend(485, 344)
+    cSend(406, 749)
+    cSend(78, 600)
+    cSend(94, 900)
+    cSend(109, 954)
+    cSend(31, 672)
+    cSend(515, 1344)
+    cSend(484, 297)
+    cSend(406, 749)
+    cSend(78, 600)
+    cSend(94, 900)
+    cSend(109, 954)
+    cSend(31, 672)
+    cSend(515, 1344)
+    cSend(469, 219)
+    cSend(297, 750)
+    cSend(156, 500)
+    cSend(110, 3000)
+    cSend(360, 2984)
+    cSend(531, 2313)
+    if BonusStage2Fail()
+        return
+    cSend(350, 1000)
+    Loop 20 {
+        Send "{Up}"
+        Sleep 500
+    }
+    if BonusStage2Fail()
+        return
+    WriteInLogs("BonusStage2SB Section 2 Complete")
+    FindPixelUntilFound(220, 465, 220, 465, 0xA0938E)
+    cSend(109, 1203)
+    cSend(31, 641)
+    cSend(47, 1200)
+    cSend(1, 3100)
+    cSend(109, 1203)
+    cSend(31, 641)
+    cSend(47, 1200)
+    cSend(1, 3100)
+    cSend(109, 1203)
+    cSend(31, 641)
+    cSend(47, 1200)
+    cSend(1, 3100)
+    cSend(109, 1203)
+    cSend(31, 641)
+    cSend(47, 5125)
+    if BonusStage2Fail()
+        return
+    cSend(900, 200)
+    Loop 20 {
+        Send "{Up}"
+        Sleep 500
+    }
+    if BonusStage2Fail()
+        return
+    WriteInLogs("BonusStage2SB Section 3 Complete")
+    FindPixelUntilFound(250, 472, 100, 250, 0x0D2030)
+    Sleep 200
+    cSend(32, 2800)
+    cSend(31, 809)
+    cSend(41, 1200)
+    cSend(100, 900)
+    cSend(641, 500)
+    cSend(31, 850)
+    cSend(41, 770)
+    cSend(641, 400)
+    cSend(31, 850)
+    cSend(41, 870)
+    cSend(641, 300)
+    cSend(31, 850)
+    cSend(41, 790)
+    cSend(641, 400)
+    cSend(31, 850)
+    cSend(41, 840)
+    cSend(641, 300)
+    cSend(31, 850)
+    cSend(41, 840)
+    cSend(641, 300)
+    Loop 23 {
+        Send "{Up}"
+        Sleep 500
+    }
+    if BonusStage2Fail()
+        return
+    WriteInLogs("BonusStage2SB Section 4 Complete")
+}
+
+BonusStage2() {
+    WriteInLogs("BonusStage2")
+    FindPixelUntilFound(220, 465, 220, 465, 0xA0938E)
+    Sleep 200
+    cSend(94, 1640)
+    cSend(32, 1218)
+    cSend(94, 600)
+    cSend(109, 1828)
+    cSend(63, 640)
+    cSend(47, 688)
+    cSend(78, 1906)
+    cSend(141, 1625)
+    cSend(47, 3187)
+    cSend(47, 734)
+    cSend(47, 750)
+    cSend(78, 1203)
+    cSend(110, 5000)
+    if BonusStage2Fail()
+        return
+    cSend(40, 5000)
+    Loop 17 {
+        Send "{Up}"
+        Sleep 500
+    }
+    if BonusStage2Fail()
+        return
+    WriteInLogs("BonusStage2 Section 1 Complete")
+    FindPixelUntilFound(780, 536, 780, 536, 0xBB26DF)
+    cSend(156, 719)
+    cSend(47, 687)
+    cSend(360, 1390)
+    cSend(485, 344)
+    cSend(406, 749)
+    cSend(78, 600)
+    cSend(94, 900)
+    cSend(109, 954)
+    cSend(31, 672)
+    cSend(515, 1344)
+    cSend(484, 297)
+    cSend(406, 749)
+    cSend(78, 600)
+    cSend(94, 900)
+    cSend(109, 954)
+    cSend(31, 672)
+    cSend(515, 1344)
+    cSend(469, 219)
+    cSend(297, 750)
+    cSend(156, 500)
+    cSend(110, 3000)
+    cSend(360, 2984)
+    cSend(531, 2313)
+    if BonusStage2Fail()
+        return
+    cSend(350, 1000)
+    Loop 20 {
+        Send "{Up}"
+        Sleep 500
+    }
+    if BonusStage2Fail()
+        return
+    WriteInLogs("BonusStage2 Section 2 Complete")
+    FindPixelUntilFound(220, 465, 220, 465, 0xA0938E)
+    cSend(109, 1203)
+    cSend(31, 641)
+    cSend(47, 1578)
+    cSend(47, 2437)
+    cSend(109, 1203)
+    cSend(31, 641)
+    cSend(47, 1578)
+    cSend(47, 2437)
+    cSend(109, 1203)
+    cSend(31, 641)
+    cSend(47, 1578)
+    cSend(47, 2437)
+    cSend(109, 1203)
+    cSend(31, 641)
+    cSend(47, 5125)
+    if BonusStage2Fail()
+        return
+    cSend(900, 200)
+    Loop 20 {
+        Send "{Up}"
+        Sleep 500
+    }
+    if BonusStage2Fail()
+        return
+    WriteInLogs("BonusStage2 Section 3 Complete")
+    FindPixelUntilFound(250, 472, 100, 250, 0x0D2030)
+    Sleep 200
+    cSend(32, 1375)
+    cSend(641, 690)
+    cSend(41, 1375)
+    cSend(41, 1374)
+    cSend(641, 690)
+    cSend(41, 1373)
+    cSend(41, 2500)
+    cSend(31, 809)
+    cSend(41, 1375)
+    cSend(41, 1374)
+    cSend(641, 690)
+    cSend(41, 1373)
+    cSend(41, 1372)
+    cSend(641, 690)
+    cSend(41, 1371)
+    cSend(41)
+    Loop 23 {
+        Send "{Up}"
+        Sleep 500
+    }
+    if BonusStage2Fail()
+        return
+    WriteInLogs("BonusStage2 Section 4 Complete")
+}
+
+BonusStage3(currentSection := 0) {
+    totalSections := 4
+    if currentSection = 0 {
+        WriteInLogs("BonusStage3")
+    } else if currentSection >= 2 * totalSections {
+        return
+    }
+    section := Mod(currentSection, totalSections)
+    if section = 0 {
+        if !BonusStage3Section1()
+            return BonusStage3(currentSection + totalSections)
+        currentSection += 1
+        section := 1
+    }
+    if section = 1 {
+        if !BonusStage3Section2()
+            return BonusStage3(currentSection + totalSections)
+        currentSection += 1
+        section := 2
+    }
+    if section = 2 {
+        if !BonusStage3Section3()
+            return BonusStage3(currentSection + totalSections)
+        currentSection += 1
+        section := 3
+    }
+    if section = 3 {
+        if !BonusStage3Section4()
+            return BonusStage3(currentSection + totalSections)
+    }
+}
+
+BonusStage3SB(currentSection := 0) {
+    totalSections := 4
+    if currentSection = 0 {
+        WriteInLogs("BonusStage3SB")
+    } else if currentSection >= 2 * totalSections {
+        return
+    }
+    section := Mod(currentSection, totalSections)
+    if section = 0 {
+        if !BonusStage3Section1(true)
+            return BonusStage3SB(currentSection + totalSections)
+        currentSection += 1
+        section := 1
+    }
+    if section = 1 {
+        if !BonusStage3Section2(true)
+            return BonusStage3SB(currentSection + totalSections)
+        currentSection += 1
+        section := 2
+    }
+    if section = 2 {
+        if !BonusStage3Section3(true)
+            return BonusStage3SB(currentSection + totalSections)
+        currentSection += 1
+        section := 3
+    }
+    if section = 3 {
+        if !BonusStage3Section4(true)
+            return BonusStage3SB(currentSection + totalSections)
+    }
+}
+
+BonusStage3Section1(spiritBoost := false) {
+    FindPixelUntilFound(520, 200, 580, 250, 0xFFFFFF)
+    Sleep 360
+    cSend(140, 530)
+    cSend(70, 640)
+    cSend(80, 740)
+    cSend(150, 765)
+    cSend(65, 625)
+    cSend(65, 500)
+    FindPixelUntilFound(540, 335, 555, 360, 0xFFFFFF, 700)
+    cSend(150, 750)
+    cSend(200, 200)
+    FindPixelUntilFound(390, 230, 410, 250, 0xFFFFFF, 3500)
+    cSend(130, 545)
+    cSend(70, 620)
+    cSend(80, 400)
+    FindPixelUntilFound(500, 200, 515, 250, 0xFFFFFF, 1500)
+    cSend(150, 755)
+    cSend(65, 625)
+    cSend(65, 500)
+    FindPixelUntilFound(540, 335, 555, 360, 0xFFFFFF, 700)
+    cSend(150, 740)
+    cSend(200, 1490)
+    cSend(110, 580)
+    cSend(65, 640)
+    cSend(80, 740)
+    cSend(150, 765)
+    cSend(130, 560)
+    cSend(70, 650)
+    Sleep 800
+    if !CollectLootBS3(spiritBoost, 21)
+        return false
+    WriteInLogs(GetBS3LogText(spiritBoost) " Section 1 Complete")
+    return true
+}
+
+BonusStage3Section2(spiritBoost := false) {
+    FindPixelUntilFound(306, 200, 309, 275, 0xFFFFFF)
+    Loop 2 {
+        cSend(80, 440)
+        cSend(95, 660)
+        cSend(105, 500)
+        FindPixelUntilFound(475, 445, 482, 475, 0xFFFFFF, 1000)
+        cSend(79, 601)
+        cSend(63, 980)
+        cSend(82, 440)
+        cSend(95, 660)
+        cSend(48, 750)
+        FindPixelUntilFound(515, 265, 522, 285, 0xFFFFFF, 1200)
+        cSend(63, 500)
+        BonusStage3WallJump(1)
+        Sleep 80
+        BonusStage3WallJump(1)
+        Sleep 300
+        BonusStage3WallJump(4)
+        FindPixelUntilFound(306, 200, 309, 275, 0xFFFFFF, 1000)
+    }
+    cSend(80, 440)
+    cSend(95, 660)
+    if !CollectLootBS3(spiritBoost)
+        return false
+    WriteInLogs(GetBS3LogText(spiritBoost) " Section 2 Complete")
+    return true
+}
+
+BonusStage3Section3(spiritBoost := false) {
+    upperWay := false
+    FindPixelUntilFound(280, 385, 330, 435, 0xFFFFFF)
+    Sleep 600
+    Loop 2 {
+        if upperWay {
+            BonusStage3WallJump()
+            upperWay := false
+        } else {
+            cSend(120, 100)
+            FindPixelUntilFound(205, 395, 215, 410, 0xFFFFFF, 780)
+            cSend(95, 225)
+            BonusStage3WallJump()
+        }
+        Sleep 2000
+        cSend(300, 500)
+        BonusStage3WallJump()
+        FindPixelUntilFound(205, 395, 215, 410, 0xFFFFFF, 900)
+        if A_Index < 3 {
+            cSend(95, 250)
+            BonusStage3WallJump(1, 715)
+            BonusStage3WallJump(6)
+            found := FindPixelUntilFound(300, 415, 330, 435, 0xFFFFFF, spiritBoost ? 1000 : 2500)
+            if !found {
+                upperWay := true
+            } else {
+                Sleep 2500
+            }
+            Sleep 150
+        }
+    }
+    if !CollectLootBS3(spiritBoost)
+        return false
+    WriteInLogs(GetBS3LogText(spiritBoost) " Section 3 Complete")
+    return true
+}
+
+BonusStage3WallJump(count := 5, sleepTime := 50) {
+    Loop count {
+        cSend(30, sleepTime)
+    }
+}
+
+BonusStage3Section4(spiritBoost := false) {
+    FindPixelUntilFound(330, 170, 380, 195, 0xFFFFFF)
+    if !spiritBoost {
+        Loop 5 {
+            cSend(300, 600)
+            cSend(300, 420)
+            cSend(35, 748)
+            cSend(35, 540)
+            cSend(35, 1160)
+        }
+    } else {
+        Loop 14 {
+            cSend(110, 1180)
+        }
+        cSend(300, 300)
+    }
+    if !CollectLootBS3(spiritBoost, 25, false)
+        return false
+    WriteInLogs(GetBS3LogText(spiritBoost) " Section 4 Complete")
+    return true
+}
+
+GetBS3LogText(spiritBoost) {
+    return "BonusStage3" (spiritBoost ? "SB" : "")
+}
+
+CollectLootBS3(spiritBoost, count := 25, stopEarly := true) {
+    if BonusStage3Fail(spiritBoost)
+        return false
+    Loop count {
+        if stopEarly && A_Index > 8 {
+            pos := FindPixelUntilFound(1100, 240, 1100, 440, 0x8D87A2, 480)
+            if IsObject(pos)
+                break
+        } else {
+            Sleep 500
+        }
+        cSend(0, 0)
+    }
+    if BonusStage3Fail(spiritBoost)
+        return false
+    return true
+}

--- a/Autohotkey/Libraries/BossFightKnight.ahk
+++ b/Autohotkey/Libraries/BossFightKnight.ahk
@@ -1,0 +1,152 @@
+#Requires AutoHotkey v2.0
+#Include "Common.ahk"
+
+BossFightKnight() {
+    WriteInLogs("Start of BossFight Knight")
+    Loop {
+        Slider()
+        Sleep 500
+        if !PixelFind(653, 222, 653, 222, 0xFFF38F)
+            break
+    }
+    BossBattleKnight()
+}
+
+BossBattleKnight() {
+    Global bFirstStage := true
+    Global bDashAttack := false
+    attackWindow := 1800
+    waitTimer := TimerInit()
+    attackTimer := TimerInit()
+    bossTimer := TimerInit()
+
+    Loop 9 {
+        ShootKnight()
+    }
+
+    while true {
+        if attackWindow < TimerDiff(attackTimer) {
+            if (pos := PixelFind(900, 150, 900, 343, 0x2C2C2C)) {
+                attackTimer := TimerInit()
+                RangeAttackKnight(pos)
+            }
+            if (pos := PixelFind(445, 210, 445, 387, 0xAF9967)) {
+                attackTimer := TimerInit()
+                CloseAttackKnight(pos)
+            } else if (pos := PixelFind(445, 210, 445, 387, 0xD7CCB3)) {
+                attackTimer := TimerInit()
+                CloseAttackKnight(pos)
+            }
+        }
+
+        if 1000 < TimerDiff(waitTimer) {
+            if bFirstStage {
+                if PixelFind(267, 130, 272, 130, 0xF5B784) {
+                    WriteInLogs("Knight Stage 2")
+                    Loop {
+                        Sleep 100
+                        MouseClick "L", 1020, 420, 1, 0
+                        if !PixelFind(272, 130, 272, 130, 0xF5B784)
+                            break
+                    }
+                    ControlFocus "Idle Slayer"
+                    bFirstStage := false
+                    bDashAttack := true
+                }
+            }
+
+            if PixelFind(535, 75, 535, 75, 0x000000) {
+                WriteInLogs("Knight Dark stage")
+                darkTimer := TimerInit()
+                loop {
+                    MouseClick "L", 1000, 328, 1, 0
+                    if PixelFind(835, 477, 835, 477, 0xFD3169) {
+                        Sleep 500
+                        MouseClick "L", 615, 563, 1, 0
+                        WriteInLogs("Knight Won")
+                        return
+                    }
+                    if TimerDiff(darkTimer) > 30000
+                        break
+                }
+                WriteInLogs("Knight Lost")
+                break
+            }
+
+            if 200000 < TimerDiff(bossTimer) {
+                WriteInLogs("Knight Lost")
+                break
+            }
+
+            waitTimer := TimerInit()
+        }
+    }
+}
+
+CloseAttackKnight(pos) {
+    Global bDashAttack
+    Sleep 700
+    upper := pos[2] <= 283
+    if upper {
+        UpperAttackKnight()
+        if bDashAttack {
+            Sleep 500
+            ControlFocus "Idle Slayer"
+            Send "{Up down}"
+            Sleep 170
+            Send "{Up up}"
+        }
+    } else {
+        DownAttackKnight()
+        if bDashAttack {
+            Loop 11 {
+                Sleep 10
+                MouseClick "L", 1020, 420, 1, 0
+            }
+            return
+        }
+    }
+    Loop 31 {
+        Sleep 10
+        MouseClick "L", 1020, 420, 1, 0
+    }
+}
+
+RangeAttackKnight(pos) {
+    Global bDashAttack
+    Sleep 150
+    bDashAttack := false
+    upper := pos[2] <= 240
+    if upper {
+        UpperAttackKnight()
+    } else {
+        DownAttackKnight()
+    }
+    Loop 25 {
+        Sleep 10
+        MouseClick "L", 1020, 420, 1, 0
+    }
+}
+
+DownAttackKnight() {
+    ControlFocus "Idle Slayer"
+    Send "{Up down}"
+    Sleep 170
+    Send "{Up up}"
+}
+
+UpperAttackKnight() {
+    Sleep 730
+}
+
+ShootKnight() {
+    Sleep 200
+    ControlFocus "Idle Slayer"
+    Send "{Up down}"
+    Sleep 300
+    Send "{Up up}"
+    Loop 14 {
+        Sleep 5
+        Send "{Up}"
+    }
+}

--- a/Autohotkey/Libraries/BossFightVictor.ahk
+++ b/Autohotkey/Libraries/BossFightVictor.ahk
@@ -1,0 +1,126 @@
+#Requires AutoHotkey v2.0
+#Include "Common.ahk"
+
+BossFightVictor() {
+    WriteInLogs("Start of BossFight Victor")
+    Loop {
+        Slider()
+        Sleep 500
+        if !PixelFind(653, 222, 653, 222, 0xFFF38F)
+            break
+    }
+    BossBattleVictor()
+}
+
+BossBattleVictor() {
+    Global bFirstStage
+    ControlFocus "Idle Slayer"
+    SetTimer Shoot, 50
+    Sleep 5000
+    bFirstStage := true
+    timeWindow := 2000
+    stageTimer := TimerInit()
+    bossTimer := TimerInit()
+    while true {
+        if !bFirstStage {
+            if PixelFind(1072, 150, 1072, 488, 0xFFFFFF) {
+                FlameAttackVictor()
+            }
+        }
+        if (pos := PixelFind(919, 292, 919, 452, 0xFFFFFF)) {
+            SetTimer Shoot, 0
+            NormalAttackVictor(pos)
+        }
+
+        if timeWindow < TimerDiff(stageTimer) {
+            if PixelFind(835, 477, 835, 477, 0xFD3169) {
+                SetTimer Shoot, 0
+                Sleep 500
+                MouseClick "L", 615, 563
+                WriteInLogs("Victor Won")
+                break
+            }
+            if bFirstStage {
+                if PixelFind(272, 130, 272, 130, 0xAE6C37) {
+                    bFirstStage := false
+                    timeWindow := 10000
+                    WriteInLogs("Victor Stage 2")
+                    SetTimer Shoot, 50
+                    Loop {
+                        Sleep 50
+                        if !PixelFind(272, 130, 272, 130, 0xAE6C37)
+                            break
+                    }
+                    Sleep 4000
+                    SetTimer Shoot, 0
+                    ControlFocus "Idle Slayer"
+                }
+            }
+            if 200000 < TimerDiff(bossTimer) {
+                SetTimer Shoot, 0
+                WriteInLogs("Victor Lost")
+                break
+            }
+            stageTimer := TimerInit()
+        }
+    }
+}
+
+NormalAttackVictor(pos) {
+    Global bFirstStage
+    upper := true
+    if pos[2] > 370 {
+        upper := false
+    }
+    if upper {
+        UpperAttackVictor()
+    } else {
+        DownAttackVictor()
+    }
+}
+
+FlameAttackVictor() {
+    Sleep 350
+    ControlFocus "Idle Slayer"
+    Send "{Up down}"
+    Sleep 100
+    Send "{Up up}"
+    Loop 18 {
+        Sleep 10
+        Send "{Up}"
+    }
+}
+
+DownAttackVictor() {
+    Global bFirstStage
+    Sleep 200
+    if bFirstStage {
+        SetTimer Shoot, 50
+    } else {
+        ControlFocus "Idle Slayer"
+        Send "{Up down}"
+        Sleep 100
+        Send "{Up up}"
+        Loop 18 {
+            Sleep 10
+            Send "{Up}"
+        }
+    }
+}
+
+UpperAttackVictor() {
+    Global bFirstStage
+    Sleep 730
+    if bFirstStage {
+        SetTimer Shoot, 50
+    } else {
+        Loop 15 {
+            Sleep 10
+            Send "{Up}"
+        }
+    }
+}
+
+Shoot() {
+    Send "{Up}"
+}

--- a/Autohotkey/Libraries/ChestHunt.ahk
+++ b/Autohotkey/Libraries/ChestHunt.ahk
@@ -1,0 +1,171 @@
+#Requires AutoHotkey v2.0
+#Include "Common.ahk"
+
+RewardChest := 0
+MimicChest := 1
+DoubleChest := 2
+ChestHuntEnd := 3
+LifeSaverChest := 4
+
+StateNoMimic := 0
+StateOneMimic := 1
+StateTwoMimics := 2
+StateOpenLifeSaver := 3
+StateNormal := 4
+
+Chesthunt(noLockpickingState, perfectChestHuntState, noReinforcedCrystalSaverState) {
+    global RewardChest, MimicChest, DoubleChest, ChestHuntEnd, LifeSaverChest
+    global StateNoMimic, StateOneMimic, StateTwoMimics, StateOpenLifeSaver, StateNormal
+    currentState := StateNoMimic
+    WriteInLogs("Chesthunt")
+    Sleep noLockpickingState ? 4000 : 2000
+    saverX := 0
+    saverY := 0
+    pixelX := 185
+    pixelY := 325
+    foundSaver := false
+    Loop 3 {
+        Loop 10 {
+            if PixelFind(pixelX, pixelY - 1, pixelX + 5, pixelY, 0xFFEB04) {
+                saverX := pixelX
+                saverY := pixelY
+                foundSaver := true
+                Break 2
+            }
+            pixelX += 95
+        }
+        pixelY += 95
+        pixelX := 185
+    }
+
+    pixelX := 185
+    pixelY := 325
+    count := 0
+    Loop 3 {
+        Loop 10 {
+            if pixelY = saverY && pixelX = saverX {
+                if A_Index = 10 {
+                    Break 1
+                } else {
+                    pixelX += 95
+                    continue
+                }
+            }
+
+            chestResult := OpenChest(pixelX, pixelY, noLockpickingState)
+            if chestResult = ChestHuntEnd {
+                Break 2
+            }
+
+            currentState := GetUpdatedState(count, currentState, chestResult, perfectChestHuntState, noReinforcedCrystalSaverState)
+            if currentState = StateOpenLifeSaver {
+                currentState := OpenLifeSaver(saverX, saverY, noLockpickingState)
+            }
+
+            pixelX += 95
+            count += 1
+        }
+        pixelY += 95
+        pixelX := 185
+    }
+
+    perfectChest := false
+    while true {
+        Sleep 50
+        if PixelFind(500, 694, 500, 694, 0xAF0000)
+            break
+        if PixelFind(457, 439, 457, 439, 0xF68F37) {
+            perfectChest := true
+            MouseClick "L", 457, 439, 1, 0
+        }
+    }
+
+    if perfectChest
+        WriteInLogs("Perfect ChestHunt Completed")
+    MouseClick "L", 643, 693, 1, 0
+}
+
+GetUpdatedState(count, currentState, chest, perfectChestHuntState, noReinforcedCrystalSaverState) {
+    global RewardChest, MimicChest, DoubleChest, LifeSaverChest
+    global StateNoMimic, StateOneMimic, StateTwoMimics, StateOpenLifeSaver, StateNormal
+
+    if currentState = StateNormal || chest = LifeSaverChest
+        return StateNormal
+
+    if chest = DoubleChest
+        return StateOpenLifeSaver
+
+    if perfectChestHuntState {
+        perfectState := PerfectChestHuntState(chest, currentState, count)
+        if perfectState != -1
+            return perfectState
+    }
+
+    if count = 0 {
+        if noReinforcedCrystalSaverState
+            return StateOpenLifeSaver
+        switch chest {
+            case RewardChest:
+                return StateNoMimic
+            case MimicChest:
+                return StateOneMimic
+        }
+    } else if count = 1 {
+        if !perfectChestHuntState
+            return StateOpenLifeSaver
+        switch currentState {
+            case StateNoMimic:
+                switch chest {
+                    case RewardChest:
+                        return StateNoMimic
+                    case MimicChest:
+                        return StateOneMimic
+                }
+            case StateOneMimic:
+                switch chest {
+                    case RewardChest:
+                        return StateOneMimic
+                    case MimicChest:
+                        return StateTwoMimics
+                }
+        }
+    }
+    return currentState
+}
+
+PerfectChestHuntState(chest, currentState, count) {
+    global RewardChest, StateNoMimic, StateOneMimic, StateTwoMimics, StateOpenLifeSaver
+    if chest = RewardChest {
+        if currentState = StateNoMimic && count = 13
+            return StateOpenLifeSaver
+        if currentState = StateOneMimic && count = 15
+            return StateOpenLifeSaver
+        if currentState = StateTwoMimics && count = 21
+            return StateOpenLifeSaver
+    }
+    return -1
+}
+
+OpenLifeSaver(saverX, saverY, noLockpickingState) {
+    global LifeSaverChest
+    MouseClick "L", saverX + 33, saverY - 23, 1, 0
+    Sleep noLockpickingState ? 1500 : 550
+    return LifeSaverChest
+}
+
+OpenChest(pixelX, pixelY, noLockpickingState) {
+    global RewardChest, MimicChest, DoubleChest, ChestHuntEnd
+    MouseClick "L", pixelX + 33, pixelY - 23, 1, 0
+    Sleep noLockpickingState ? 1500 : 550
+    if PixelFind(500, 694, 500, 694, 0xAF0000)
+        return ChestHuntEnd
+    if PixelFind(500, 210, 500, 210, 0x00FF00) {
+        Sleep 1000
+        return DoubleChest
+    }
+    if PixelFind(434, 211, 434, 211, 0xFF0000) {
+        Sleep noLockpickingState ? 2500 : 1500
+        return MimicChest
+    }
+    return RewardChest
+}

--- a/Autohotkey/Libraries/Common.ahk
+++ b/Autohotkey/Libraries/Common.ahk
@@ -1,0 +1,89 @@
+#Requires AutoHotkey v2.0
+
+setSetting() {
+    ; Enable GUI events - not directly applicable in AHK v2 but keep placeholder
+    ; Ensure CapsLock remains off for consistent background input
+    SetCapsLockState "AlwaysOff"
+    SetTitleMatchMode 2
+    ; Use window-relative coordinates for pixel/mouse operations
+    CoordMode "Pixel", "Window"
+    CoordMode "Mouse", "Window"
+    ; Attempt to switch the Idle Slayer window to the US keyboard layout
+    if WinExist("Idle Slayer") {
+        hwnd := WinExist()
+        hkl := DllCall("LoadKeyboardLayout", "Str", "00000409", "UInt", 1, "Ptr")
+        if (hkl) {
+            PostMessage 0x50, 0, hkl,, "ahk_id " hwnd  ; WM_INPUTLANGCHANGEREQUEST
+        }
+    }
+}
+
+TimerInit() {
+    return A_TickCount
+}
+
+TimerDiff(timerRef) {
+    return A_TickCount - timerRef
+}
+
+WriteInLogs(message) {
+    timestamp := FormatTime(, "yyyy-MM-dd HH:mm:ss")
+    logDir := A_ScriptDir "\\IdleRunnerLogs"
+    if !DirExist(logDir) {
+        DirCreate logDir
+    }
+    FileAppend(Format("[{1}] {2}`n", timestamp, message), logDir "\\Logs.txt", "UTF-8")
+}
+
+cSend(pressDelay, postPressDelay := 0, key := "Up") {
+    Send "{" key " Down}"
+    Sleep pressDelay
+    Send "{" key " Up}"
+    Sleep postPressDelay
+}
+
+FindPixelUntilFound(x1, y1, x2, y2, color, timer := 15000, variation := 0) {
+    start := A_TickCount
+    Loop {
+        if PixelSearch(&foundX, &foundY, x1, y1, x2, y2, color, variation) {
+            return [foundX, foundY]
+        }
+        if (A_TickCount - start) > timer {
+            return false
+        }
+        Sleep 10
+    }
+}
+
+PixelFind(x1, y1, x2, y2, color, variation := 0) {
+    if PixelSearch(&foundX, &foundY, x1, y1, x2, y2, color, variation) {
+        return [foundX, foundY]
+    }
+    return false
+}
+
+Slider() {
+    if PixelSearch(&x, &y, 443, 560, 443, 560, 0x007E00) {
+        MouseMove 840, 560, 0
+        MouseClickDrag "L", 840, 560, 450, 560, 0
+        return
+    }
+
+    if PixelSearch(&x, &y, 443, 620, 443, 620, 0x007E00) {
+        MouseMove 840, 620, 0
+        MouseClickDrag "L", 840, 620, 450, 620, 0
+        return
+    }
+
+    if PixelSearch(&x, &y, 850, 560, 850, 560, 0x007E00) {
+        MouseMove 450, 560, 0
+        MouseClickDrag "L", 450, 560, 840, 560, 0
+        return
+    }
+
+    if PixelSearch(&x, &y, 850, 620, 850, 620, 0x007E00) {
+        MouseMove 450, 620, 0
+        MouseClickDrag "L", 450, 620, 840, 620, 0
+        return
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 (Works only with the Steam Version on Windows)
 
-You have two options:
+You have three options:
 
 1) **Run with _.exe files** (easy):
 
@@ -24,13 +24,19 @@ You have two options:
    
    ![image](https://github.com/Devil4ngle/Idle_Slayer_Script/assets/101042789/df50f05b-530e-4777-bfd3-5012adf77baf)
 
-    - Right-click the file `Idle Runner.au3` and click `Compile with Options`
+   - Right-click the file `Idle Runner.au3` and click `Compile with Options`
 
     ![image](https://github.com/Devil4ngle/Idle_Slayer_Script/assets/101042789/5dc44eb5-aa9a-435f-82fb-710526cc4795)
-   
+
     - In the menu click `Compile Script`.
-      
+
    It will generate exe files which should run without issue.
+
+3) **Run the AutoHotkey port**:
+
+    - Install [AutoHotkey v2](https://www.autohotkey.com/download/).
+    - Open the `Autohotkey` folder from this repository.
+    - Double-click `Idle Runner.ahk` to launch the re-written script or compile it with `Ahk2Exe` if you prefer an executable.
 
 # Settings
 


### PR DESCRIPTION
## Summary
- add a new AutoHotkey implementation of the Idle Runner automation with modular libraries mirroring the AutoIt logic
- recreate bonus stage, boss fight, chest hunt, and support utilities in AHK to preserve gameplay automation features
- document the new AutoHotkey option alongside the original AutoIt workflow in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db2e91f3d483248dbc8e3ee1ab93f9